### PR TITLE
Add forwarding mechanism for proxying to abbrv locally.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ serde_json = "1.0.83"
 [[bin]]
 name = "abbrv"
 path = "src/main.rs"
+
+[[bin]]
+name = "abbrv_forward"
+path = "src/forward.rs"

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate rocket;
+
+use std::env;
+use rocket::response::Redirect;
+use rocket::response::status::NotFound;
+use rocket::State;
+
+struct AbbrvForwardConfig {
+    url: String,
+}
+
+#[get("/<key>")]
+async fn link(key: &str, config: &State<AbbrvForwardConfig>) -> Result<Redirect, NotFound<String>> {
+    return Ok(Redirect::temporary(config.url.to_string() + "/" + key));
+}
+
+#[launch]
+fn rocket() -> _ {
+    let url = env::var("ABBRV_URL").expect("Missing env ABBRV_URL");
+    let config = AbbrvForwardConfig {
+        url: url
+    };
+
+    rocket::build().manage({
+        config
+    }).mount("/", routes![link])
+}


### PR DESCRIPTION
This adds a simple mechanism which hosts a server that forward all links to another abbrv server. This can be used to setup local servers that bind on localhost and forward to another instance.